### PR TITLE
fix: Don't fatal error when we can return an error

### DIFF
--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -625,8 +625,7 @@ func ConfigureOpenTelemetry(opts ...Option) (func(), error) {
 	for _, setup := range []setupFunc{setupTracing, setupMetrics} {
 		shutdown, err := setup(c)
 		if err != nil {
-			c.Logger.Fatalf("setup error: %v", err)
-			continue
+			return nil, fmt.Errorf("setup error: %w", err)
 		}
 		if shutdown != nil {
 			otelConfig.shutdownFuncs = append(otelConfig.shutdownFuncs, shutdown)

--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -625,7 +625,7 @@ func ConfigureOpenTelemetry(opts ...Option) (func(), error) {
 	for _, setup := range []setupFunc{setupTracing, setupMetrics} {
 		shutdown, err := setup(c)
 		if err != nil {
-			return nil, fmt.Errorf("setup error: %w", err)
+			return otelConfig.Shutdown, fmt.Errorf("setup error: %w", err)
 		}
 		if shutdown != nil {
 			otelConfig.shutdownFuncs = append(otelConfig.shutdownFuncs, shutdown)

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -219,20 +219,19 @@ func TestInvalidMetricsPushIntervalEnv(t *testing.T) {
 	setenv("OTEL_EXPORTER_OTLP_METRICS_PERIOD", "300million")
 
 	logger := &testLogger{}
-	shutdown, _ := ConfigureOpenTelemetry(
+	shutdown, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithServiceName("test-service"),
 		withTestExporters(),
 	)
 	defer shutdown()
-
-	logger.requireContains(t, "setup error: invalid metric reporting period")
+	assert.ErrorContains(t, err, "setup error: invalid metric reporting period")
 	unsetEnvironment()
 }
 
 func TestInvalidMetricsPushIntervalConfig(t *testing.T) {
 	logger := &testLogger{}
-	shutdown, _ := ConfigureOpenTelemetry(
+	shutdown, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithServiceName("test-service"),
 		WithMetricsReportingPeriod(-time.Second),
@@ -240,7 +239,7 @@ func TestInvalidMetricsPushIntervalConfig(t *testing.T) {
 	)
 	defer shutdown()
 
-	logger.requireContains(t, "setup error: invalid metric reporting period")
+	assert.ErrorContains(t, err, "setup error: invalid metric reporting period")
 	unsetEnvironment()
 }
 
@@ -537,13 +536,8 @@ func TestConfigurePropagators3(t *testing.T) {
 		WithPropagators([]string{"invalid"}),
 		withTestExporters(),
 	)
-	assert.NoError(t, err)
 	defer shutdown()
-
-	expected := "invalid configuration: unsupported propagators. Supported options: b3,baggage,tracecontext,ottrace"
-	if !strings.Contains(logger.output[0], expected) {
-		t.Errorf("\nString not found: %v\nIn: %v", expected, logger.output[0])
-	}
+	assert.ErrorContains(t, err, "invalid configuration: unsupported propagators. Supported options: b3,baggage,tracecontext,ottrace")
 }
 
 func host() string {


### PR DESCRIPTION
## Which problem is this PR solving?

Calling this code:
```go
	otelshutdown, err := otelconfig.ConfigureOpenTelemetry(
                 otelconfig.WithExporterProtocol(otelconfig.ProtocolHTTPJSON)))
```
Crashes with a fatal error, even though the function returns an error.

It would be nice to be able to catch this error and handle it in my app appropriately.

## Short description of the changes

Return a wrapped error instead of crashing. Note that this also affects other setup-type errors that are currently fatally crashing, and required reworking some tests.

## How to verify that this has the expected result

Run the tests, or the code above; `err` should come back as non-nil and it shouldn't crash.