### PR TITLE
maint: drop go 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["18", "19", "20"]
+      goversion: ["19", "20"]
 
 default_goversion: &default_goversion "20"
 


### PR DESCRIPTION
## Which problem is this PR solving?

- upstream otel dropped support for go 1.18 in v1.15.0
- see #35 

## How to verify that this has the expected result

- tests run