### PR TITLE
feat: Add resource option configuration

### DIFF
--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -154,6 +154,14 @@ func WithResourceAttributes(attributes map[string]string) Option {
 	}
 }
 
+// WithResourceOption configures options on the resource; These are appended
+// after the default options and can override them.
+func WithResourceOption(option resource.Option) Option {
+	return func(c *Config) {
+		c.ResourceOptions = append(c.ResourceOptions, option)
+	}
+}
+
 // WithPropagators configures propagators.
 func WithPropagators(propagators []string) Option {
 	return func(c *Config) {
@@ -316,6 +324,7 @@ type Config struct {
 	ResourceAttributes              map[string]string
 	SpanProcessors                  []trace.SpanProcessor
 	Sampler                         trace.Sampler
+	ResourceOptions                 []resource.Option
 	Resource                        *resource.Resource
 	Logger                          Logger                  `json:"-"`
 	ShutdownFunctions               []func(c *Config) error `json:"-"`
@@ -411,11 +420,17 @@ func newResource(c *Config) *resource.Resource {
 
 	attributes = append(r.Attributes(), attributes...)
 
+	baseOptions := []resource.Option{
+		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithAttributes(attributes...),
+	}
+
+	options := append(baseOptions, c.ResourceOptions...)
+
 	// These detectors can't actually fail, ignoring the error.
 	r, _ = resource.New(
 		context.Background(),
-		resource.WithSchemaURL(semconv.SchemaURL),
-		resource.WithAttributes(attributes...),
+		options...,
 	)
 
 	// Note: There are new detectors we may wish to take advantage

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -397,10 +397,11 @@ func TestConfigurationOverrides(t *testing.T) {
 		WithExporterProtocol("http/protobuf"),
 		WithMetricsExporterProtocol("http/protobuf"),
 		WithTracesExporterProtocol("http/protobuf"),
+		WithResourceOption(resource.WithAttributes(attribute.String("host.name", "hardcoded-hostname"))),
 	)
 
 	attributes := []attribute.KeyValue{
-		attribute.String("host.name", host()),
+		attribute.String("host.name", "hardcoded-hostname"),
 		attribute.String("service.name", "override-service-name"),
 		attribute.String("service.version", "override-service-version"),
 		attribute.String("telemetry.sdk.name", "otelconfig"),
@@ -433,6 +434,9 @@ func TestConfigurationOverrides(t *testing.T) {
 		MetricsExporterProtocol:         "http/protobuf",
 		errorHandler:                    handler,
 		Sampler:                         trace.AlwaysSample(),
+		ResourceOptions: []resource.Option{
+			resource.WithAttributes(attribute.String("host.name", "hardcoded-hostname")),
+		},
 	}
 	assert.Equal(t, expected, config)
 	unsetEnvironment()

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -377,6 +377,15 @@ func TestEnvironmentVariables(t *testing.T) {
 	unsetEnvironment()
 }
 
+type testDetector struct{}
+
+var _ resource.Detector = (*testDetector)(nil)
+
+// Detect implements resource.Detector.
+func (testDetector) Detect(ctx context.Context) (*resource.Resource, error) {
+	return resource.New(ctx)
+}
+
 func TestConfigurationOverrides(t *testing.T) {
 	setEnvironment()
 	logger := &testLogger{}
@@ -398,6 +407,7 @@ func TestConfigurationOverrides(t *testing.T) {
 		WithMetricsExporterProtocol("http/protobuf"),
 		WithTracesExporterProtocol("http/protobuf"),
 		WithResourceOption(resource.WithAttributes(attribute.String("host.name", "hardcoded-hostname"))),
+		WithResourceOption(resource.WithDetectors(&testDetector{})),
 	)
 
 	attributes := []attribute.KeyValue{
@@ -436,6 +446,7 @@ func TestConfigurationOverrides(t *testing.T) {
 		Sampler:                         trace.AlwaysSample(),
 		ResourceOptions: []resource.Option{
 			resource.WithAttributes(attribute.String("host.name", "hardcoded-hostname")),
+			resource.WithDetectors(&testDetector{}),
 		},
 	}
 	assert.Equal(t, expected, config)


### PR DESCRIPTION
## Which problem is this PR solving?

We are unable to add resource detectors when configuring the launcher.

- Closes #12

## Short description of the changes

Rather than adding a specific `WithDetectors` func to mirror the functionality in the [resource package](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#WithDetectors) this adds a more generic version so that any resource option configuration can be provided.

This has been done in a backwards compatible manner but I could see a future where the `WithResourceAttributes` function is removed as it is duplicate functionality now.

## How to verify that this has the expected result

Unit tests have been added