### PR TITLE
feat: Add WithResourceOption for additional resource configuration

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -5,12 +5,21 @@ import (
 	"log"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	"github.com/honeycombio/otel-config-go/otelconfig"
 )
 
 func main() {
-	otelShutdown, err := otelconfig.ConfigureOpenTelemetry()
+	otelShutdown, err := otelconfig.ConfigureOpenTelemetry(
+		otelconfig.WithResourceOption(
+			resource.WithAttributes(
+				attribute.String("resource.example_set_in_code", "CODE"),
+				attribute.String("resource.example_clobber", "CODE_WON"),
+			),
+		),
+	)
 
 	if err != nil {
 		log.Fatalf("error setting up OTel SDK - %e", err)
@@ -18,7 +27,6 @@ func main() {
 
 	defer otelShutdown()
 	tracer := otel.Tracer("my-app")
-	ctx := context.Background()
-	ctx, span := tracer.Start(ctx, "doing-things")
+	_, span := tracer.Start(context.Background(), "doing-things")
 	defer span.End()
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -27,6 +27,7 @@ func main() {
 
 	defer otelShutdown()
 	tracer := otel.Tracer("my-app")
-	_, span := tracer.Start(context.Background(), "doing-things")
+	ctx := context.Background()
+	ctx, span := tracer.Start(ctx, "doing-things")
 	defer span.End()
 }

--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -154,6 +154,14 @@ func WithResourceAttributes(attributes map[string]string) Option {
 	}
 }
 
+// WithResourceOption configures options on the resource; These are appended
+// after the default options and can override them.
+func WithResourceOption(option resource.Option) Option {
+	return func(c *Config) {
+		c.ResourceOptions = append(c.ResourceOptions, option)
+	}
+}
+
 // WithPropagators configures propagators.
 func WithPropagators(propagators []string) Option {
 	return func(c *Config) {
@@ -316,6 +324,7 @@ type Config struct {
 	ResourceAttributes              map[string]string
 	SpanProcessors                  []trace.SpanProcessor
 	Sampler                         trace.Sampler
+	ResourceOptions                 []resource.Option
 	Resource                        *resource.Resource
 	Logger                          Logger                  `json:"-"`
 	ShutdownFunctions               []func(c *Config) error `json:"-"`
@@ -411,11 +420,17 @@ func newResource(c *Config) *resource.Resource {
 
 	attributes = append(r.Attributes(), attributes...)
 
+	baseOptions := []resource.Option{
+		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithAttributes(attributes...),
+	}
+
+	options := append(baseOptions, c.ResourceOptions...)
+
 	// These detectors can't actually fail, ignoring the error.
 	r, _ = resource.New(
 		context.Background(),
-		resource.WithSchemaURL(semconv.SchemaURL),
-		resource.WithAttributes(attributes...),
+		options...,
 	)
 
 	// Note: There are new detectors we may wish to take advantage

--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -427,11 +427,14 @@ func newResource(c *Config) *resource.Resource {
 
 	options := append(baseOptions, c.ResourceOptions...)
 
-	// These detectors can't actually fail, ignoring the error.
-	r, _ = resource.New(
+	r, err := resource.New(
 		context.Background(),
 		options...,
 	)
+
+	if err != nil {
+		c.Logger.Debugf("error applying resource options: %s", err)
+	}
 
 	// Note: There are new detectors we may wish to take advantage
 	// of, now available in the default SDK (e.g., WithProcess(),

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -377,6 +377,15 @@ func TestEnvironmentVariables(t *testing.T) {
 	unsetEnvironment()
 }
 
+type testDetector struct{}
+
+var _ resource.Detector = (*testDetector)(nil)
+
+// Detect implements resource.Detector.
+func (testDetector) Detect(ctx context.Context) (*resource.Resource, error) {
+	return resource.New(ctx)
+}
+
 func TestConfigurationOverrides(t *testing.T) {
 	setEnvironment()
 	logger := &testLogger{}
@@ -397,10 +406,12 @@ func TestConfigurationOverrides(t *testing.T) {
 		WithExporterProtocol("http/protobuf"),
 		WithMetricsExporterProtocol("http/protobuf"),
 		WithTracesExporterProtocol("http/protobuf"),
+		WithResourceOption(resource.WithAttributes(attribute.String("host.name", "hardcoded-hostname"))),
+		WithResourceOption(resource.WithDetectors(&testDetector{})),
 	)
 
 	attributes := []attribute.KeyValue{
-		attribute.String("host.name", host()),
+		attribute.String("host.name", "hardcoded-hostname"),
 		attribute.String("service.name", "override-service-name"),
 		attribute.String("service.version", "override-service-version"),
 		attribute.String("telemetry.sdk.name", "otelconfig"),
@@ -433,6 +444,10 @@ func TestConfigurationOverrides(t *testing.T) {
 		MetricsExporterProtocol:         "http/protobuf",
 		errorHandler:                    handler,
 		Sampler:                         trace.AlwaysSample(),
+		ResourceOptions: []resource.Option{
+			resource.WithAttributes(attribute.String("host.name", "hardcoded-hostname")),
+			resource.WithDetectors(&testDetector{}),
+		},
 	}
 	assert.Equal(t, expected, config)
 	unsetEnvironment()

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -418,7 +418,7 @@ func TestConfigurationOverrides(t *testing.T) {
 	expectedConfiguredResource := resource.NewWithAttributes(
 		semconv.SchemaURL,
 		attribute.String("host.name", "hardcoded-hostname"),
-		attribute.String("resource.clobber", "ENV_WON"),
+		attribute.String("resource.clobber", "CODE_WON"),
 		attribute.String("service.name", "override-service-name"),
 		attribute.String("service.version", "override-service-version"),
 		attribute.String("telemetry.sdk.name", "otelconfig"),

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.0'
 x-env-base: &env_base
   OTEL_EXPORTER_OTLP_ENDPOINT: http://collector:4317
   OTEL_EXPORTER_OTLP_INSECURE: "true"
+  OTEL_RESOURCE_ATTRIBUTES: resource.example_set_in_env=ENV,resource.example_clobber=ENV_WON
   OTEL_SERVICE_NAME: "my-go-app"
   OTEL_METRICS_ENABLED: "false"
   DEBUG: "true"

--- a/smoke-tests/smoke-sdk-grpc.bats
+++ b/smoke-tests/smoke-sdk-grpc.bats
@@ -27,3 +27,18 @@ teardown_file() {
 	result=$(span_names_for ${TRACER_NAME})
 	assert_equal "$result" '"doing-things"'
 }
+
+@test "Resource attributes can be set via environment variable" {
+	env_result=$(spans_received | jq ".resource.attributes[] | select(.key == \"resource.example_set_in_env\") | .value.stringValue")
+	assert_equal "$env_result" '"ENV"'
+}
+
+@test "Resource attributes can be set in code" {
+	code_result=$(spans_received | jq ".resource.attributes[] | select(.key == \"resource.example_set_in_code\") | .value.stringValue")
+	assert_equal "$code_result" '"CODE"'
+}
+
+@test "Resource attributes set in environment win over matching key set in code" {
+	clobber_result=$(spans_received | jq ".resource.attributes[] | select(.key == \"resource.example_clobber\") | .value.stringValue")
+	assert_equal "$clobber_result" '"ENV_WON"'
+}

--- a/smoke-tests/smoke-sdk-grpc.bats
+++ b/smoke-tests/smoke-sdk-grpc.bats
@@ -38,7 +38,7 @@ teardown_file() {
 	assert_equal "$code_result" '"CODE"'
 }
 
-@test "Resource attributes set in environment win over matching key set in code" {
+@test "Resource attributes set in code win over matching key set in environment" {
 	clobber_result=$(spans_received | jq ".resource.attributes[] | select(.key == \"resource.example_clobber\") | .value.stringValue")
-	assert_equal "$clobber_result" '"ENV_WON"'
+	assert_equal "$clobber_result" '"CODE_WON"'
 }

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -27,3 +27,18 @@ teardown_file() {
 	result=$(span_names_for ${TRACER_NAME})
 	assert_equal "$result" '"doing-things"'
 }
+
+@test "Resource attributes can be set via environment variable" {
+	env_result=$(spans_received | jq ".resource.attributes[] | select(.key == \"resource.example_set_in_env\") | .value.stringValue")
+	assert_equal "$env_result" '"ENV"'
+}
+
+@test "Resource attributes can be set in code" {
+	code_result=$(spans_received | jq ".resource.attributes[] | select(.key == \"resource.example_set_in_code\") | .value.stringValue")
+	assert_equal "$code_result" '"CODE"'
+}
+
+@test "Resource attributes set in environment win over matching key set in code" {
+	clobber_result=$(spans_received | jq ".resource.attributes[] | select(.key == \"resource.example_clobber\") | .value.stringValue")
+	assert_equal "$clobber_result" '"ENV_WON"'
+}

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -38,7 +38,7 @@ teardown_file() {
 	assert_equal "$code_result" '"CODE"'
 }
 
-@test "Resource attributes set in environment win over matching key set in code" {
+@test "Resource attributes set in code win over matching key set in environment" {
 	clobber_result=$(spans_received | jq ".resource.attributes[] | select(.key == \"resource.example_clobber\") | .value.stringValue")
-	assert_equal "$clobber_result" '"ENV_WON"'
+	assert_equal "$clobber_result" '"CODE_WON"'
 }


### PR DESCRIPTION
## Which problem is this PR solving?

We are unable to add resource detectors when configuring the launcher.

- Closes #12

## Short description of the changes

Implementation starts with what was written for #47 with smoke tests added to verify the order of precedence for resources attributes from environment over code.

[vera] upon further inspection, the original behavior of CODE attributes winning over ENV attributes was valid:

> The SDK MUST extract information from the OTEL_RESOURCE_ATTRIBUTES environment variable and [merge](https://opentelemetry.io/docs/specs/otel/resource/sdk/#merge) this, as the secondary resource, with any resource information provided by the user, i.e. the user provided resource information has higher priority.
— [OTel Resource SDK spec](https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable)

“user provided resource information” -- the user could mean the application code writer OR the operator setting environment variables. It’s ambiguous! And *not* settled in the spec: https://github.com/open-telemetry/opentelemetry-specification/issues/1620

See note in that issue: 
>others in the Go SIG have interpreted this passage to require that resource attributes from the environment must be subordinated to any resource attributes provided by the developer-user

This is how the underlying Go SDK works, as designed.

The CODE>ENV decision was also made in the Ruby SDK: https://github.com/robertlaurin/opentelemetry-ruby/blob/0c03e4aee09093ce0d80142e13a35326aad9f877/sdk/test/opentelemetry/sdk/configurator_test.rb#L35


Description from original PR:

Rather than adding a specific `WithDetectors` func to mirror the functionality in the [resource package](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#WithDetectors) this adds a more generic version so that any resource option configuration can be provided.

This has been done in a backwards compatible manner but I could see a future where the `WithResourceAttributes` function is removed as it is duplicate functionality now.

## How to verify that this has the expected result

- [x] Unit tests - logic's probably sound
- [x] Smoke tests - interaction with config from environment behaves according to spec