### PR TITLE
fix: revert "feat: Add resource option configuration (#47)"

### DIFF
--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -154,14 +154,6 @@ func WithResourceAttributes(attributes map[string]string) Option {
 	}
 }
 
-// WithResourceOption configures options on the resource; These are appended
-// after the default options and can override them.
-func WithResourceOption(option resource.Option) Option {
-	return func(c *Config) {
-		c.ResourceOptions = append(c.ResourceOptions, option)
-	}
-}
-
 // WithPropagators configures propagators.
 func WithPropagators(propagators []string) Option {
 	return func(c *Config) {
@@ -324,7 +316,6 @@ type Config struct {
 	ResourceAttributes              map[string]string
 	SpanProcessors                  []trace.SpanProcessor
 	Sampler                         trace.Sampler
-	ResourceOptions                 []resource.Option
 	Resource                        *resource.Resource
 	Logger                          Logger                  `json:"-"`
 	ShutdownFunctions               []func(c *Config) error `json:"-"`
@@ -420,17 +411,11 @@ func newResource(c *Config) *resource.Resource {
 
 	attributes = append(r.Attributes(), attributes...)
 
-	baseOptions := []resource.Option{
-		resource.WithSchemaURL(semconv.SchemaURL),
-		resource.WithAttributes(attributes...),
-	}
-
-	options := append(baseOptions, c.ResourceOptions...)
-
 	// These detectors can't actually fail, ignoring the error.
 	r, _ = resource.New(
 		context.Background(),
-		options...,
+		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithAttributes(attributes...),
 	)
 
 	// Note: There are new detectors we may wish to take advantage

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -377,15 +377,6 @@ func TestEnvironmentVariables(t *testing.T) {
 	unsetEnvironment()
 }
 
-type testDetector struct{}
-
-var _ resource.Detector = (*testDetector)(nil)
-
-// Detect implements resource.Detector.
-func (testDetector) Detect(ctx context.Context) (*resource.Resource, error) {
-	return resource.New(ctx)
-}
-
 func TestConfigurationOverrides(t *testing.T) {
 	setEnvironment()
 	logger := &testLogger{}
@@ -406,12 +397,10 @@ func TestConfigurationOverrides(t *testing.T) {
 		WithExporterProtocol("http/protobuf"),
 		WithMetricsExporterProtocol("http/protobuf"),
 		WithTracesExporterProtocol("http/protobuf"),
-		WithResourceOption(resource.WithAttributes(attribute.String("host.name", "hardcoded-hostname"))),
-		WithResourceOption(resource.WithDetectors(&testDetector{})),
 	)
 
 	attributes := []attribute.KeyValue{
-		attribute.String("host.name", "hardcoded-hostname"),
+		attribute.String("host.name", host()),
 		attribute.String("service.name", "override-service-name"),
 		attribute.String("service.version", "override-service-version"),
 		attribute.String("telemetry.sdk.name", "otelconfig"),
@@ -444,10 +433,6 @@ func TestConfigurationOverrides(t *testing.T) {
 		MetricsExporterProtocol:         "http/protobuf",
 		errorHandler:                    handler,
 		Sampler:                         trace.AlwaysSample(),
-		ResourceOptions: []resource.Option{
-			resource.WithAttributes(attribute.String("host.name", "hardcoded-hostname")),
-			resource.WithDetectors(&testDetector{}),
-		},
 	}
 	assert.Equal(t, expected, config)
 	unsetEnvironment()


### PR DESCRIPTION
## Which problem is this PR solving?

This implementation of adding resource attributes with code clobbers resource attributes set from environment variables which is against spec.

## Short description of the changes

This reverts commit 6365f2db2824c5a112dfdad5f9a215a0b83790ff.
