### PR TITLE
maint: Match semantic convention version to SDK semantic conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This project is a configuration layer that chooses default values for configurat
 Latest release built with:
 
 - OpenTelemetry Go [v1.16.0/v0.39.0](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.16.0)
-- OpenTelemetry Semantic Conventions [v1.17.0](https://github.com/open-telemetry/opentelemetry-go/tree/main/semconv/v1.17.0)
+- OpenTelemetry Semantic Conventions [v1.18.0](https://github.com/open-telemetry/opentelemetry-go/tree/main/semconv/v1.18.0)
+
+(Note: semantic conventions to be updated to match upstream in next release)
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This project is a configuration layer that chooses default values for configuration options that many OpenTelemetry users would ultimately configure manually, allowing for minimal code to quickly instrument with OpenTelemetry.
 
+Latest release built with:
+
+- OpenTelemetry Go [v1.16.0/v0.39.0](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.16.0)
+- OpenTelemetry Semantic Conventions [v1.17.0](https://github.com/open-telemetry/opentelemetry-go/tree/main/semconv/v1.17.0)
+
 ## Getting started
 
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,14 @@
 # Releasing
 
 - Update `version.go` with version of release.
-- Update `CHANGELOG.md` with the changes since the last release.
+- If the new release updates the OpenTelemetry SDK and/or Semantic Convention versions, update the `Latest release built with` section in the [README](./README.md).
+- Update `CHANGELOG.md` with the changes since the last release. Consider automating with a command such as these two:
+  - `git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline > new-in-this-release.log`
+  - `git log --pretty='%C(green)%d%Creset- %s | [%an](https://github.com/)'`
 - Commit changes, push, and open a release preparation pull request for review.
 - Once the pull request is merged, fetch the updated `main` branch.
 - Apply a tag for the new version on the merged commit (e.g. `git tag -a v1.2.3 -m "v1.2.3"`)
 - Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v1.2.3`
-- Open the draft GitHub release created as part of CI publish steps and "generate release notes"
-- Publish the github draft release and this will kick off publishing to GitHub.
+- Ensure that there is a draft GitHub release created as part of CI publish steps.
+- Click "generate release notes" in GitHub for full changelog notes and any new contributors
+- Publish the GitHub draft release - if it is a prerelease (e.g. beta) click the prerelease checkbox.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/sethvargo/go-envconfig v0.9.0
 	github.com/stretchr/testify v1.8.4
+	go.opentelemetry.io/contrib/detectors/aws/lambda v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/host v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.42.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+go.opentelemetry.io/contrib/detectors/aws/lambda v0.42.0 h1:xb6nqUltqyi7dVDSQ8QsxufefOxosru1XoJzsZt4gkU=
+go.opentelemetry.io/contrib/detectors/aws/lambda v0.42.0/go.mod h1:rzv6fEMvxWU2x0bgykCIhb74njjctPuyVLd9Tv/1FT8=
 go.opentelemetry.io/contrib/instrumentation/host v0.42.0 h1:/GMlvboQJd4LWxNX/oGYLv06J5a/M/flauLruM/3U2g=
 go.opentelemetry.io/contrib/instrumentation/host v0.42.0/go.mod h1:w6v1mVemRjTTdfejACjf+LgVA6zKtHOWmdAIf3icx7A=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.42.0 h1:EbmAUG9hEAMXyfWEasIt2kmh/WmXUznUksChApTgBGc=

--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -18,7 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 )
 
 var (

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	collectormetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 )

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -980,7 +980,7 @@ func TestResourceDetectorsDontError(t *testing.T) {
 	unsetEnvironment()
 }
 
-func TestAwsResourceDetectorsDontError(t *testing.T) {
+func TestContribResourceDetectorsDontError(t *testing.T) {
 	logger := &testLogger{}
 	stopper := dummyGRPCListener()
 	defer stopper()

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -965,17 +965,17 @@ func TestSemanticConventionVersionMatchesUpstream(t *testing.T) {
 }
 
 func TestResourceDetectorsDontError(t *testing.T) {
-  logger := &testLogger{}
-  stopper := dummyGRPCListener()
-  defer stopper()
+	logger := &testLogger{}
+	stopper := dummyGRPCListener()
+	defer stopper()
 
-  shutdown, err := ConfigureOpenTelemetry(
-    WithLogger(logger),
-    WithResourceOption(resource.WithHost()),
-  )
-  assert.NoError(t, err)
-  defer shutdown()
-  unsetEnvironment()
+	shutdown, err := ConfigureOpenTelemetry(
+		WithLogger(logger),
+		WithResourceOption(resource.WithHost()),
+	)
+	assert.NoError(t, err)
+	defer shutdown()
+	unsetEnvironment()
 }
 
 type testSampler struct {

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -976,6 +976,12 @@ func TestCustomDefaultExporterEndpointDoesNotReplaceOption(t *testing.T) {
 	unsetEnvironment()
 }
 
+func TestSemanticConventionVersionMatchesUpstream(t *testing.T) {
+	defaultResource := resource.Default()
+	ourSchemaURL := semconv.SchemaURL
+	assert.Equal(t, ourSchemaURL, defaultResource.SchemaURL())
+}
+
 type testSampler struct {
 	decsision  trace.SamplingDecision
 	attributes []attribute.KeyValue

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -982,6 +982,20 @@ func TestSemanticConventionVersionMatchesUpstream(t *testing.T) {
 	assert.Equal(t, ourSchemaURL, defaultResource.SchemaURL())
 }
 
+func TestResourceDetectorsDontError(t *testing.T) {
+  logger := &testLogger{}
+  stopper := dummyGRPCListener()
+  defer stopper()
+
+  shutdown, err := ConfigureOpenTelemetry(
+    WithLogger(logger),
+    WithResourceOption(resource.WithHost()),
+  )
+  assert.NoError(t, err)
+  defer shutdown()
+  unsetEnvironment()
+}
+
 type testSampler struct {
 	decsision  trace.SamplingDecision
 	attributes []attribute.KeyValue


### PR DESCRIPTION
## Which problem is this PR solving?

- it's easy to mismatch semantic convention versions (see notes in #59 )

## Short description of the changes

- Drop our version of semantic conventions to 1.17 to match those used in the imported otel-go package
- Update the README to clarify versions in use (note old semconv listed because that's in current available release)
- Update releasing notes to remember to adjust README if versions change, and some other cleanup for consistency to other repos
- Add simple unit test for checking semantic convention version against otel-go imported package semantic convention
- Add unit tests for resource detector from core (WithHost) and contrib (lambda) to confirm no schema error

## How to verify that this has the expected result

Using a detector on the same version should work. These tests should fail if you change the semantic convention version back to 1.18.0 in the imports. 