### PR TITLE
maint: add release.yml for auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - no-changelog
+  categories:
+    - title: 💥 Breaking Changes 💥
+      labels:
+        - "version: bump major"
+        - breaking-change
+    - title: 💡 Enhancements
+      labels:
+        - "type: enhancement"
+    - title: 🐛 Fixes
+      labels:
+        - "type: bug"
+    - title: 🛠 Maintenance
+      labels:
+        - "type: maintenance"
+    - title: 🤷 Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,6 +18,7 @@ changelog:
     - title: 🛠 Maintenance
       labels:
         - "type: maintenance"
+        - "type: dependencies"
     - title: 🤷 Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## Which problem is this PR solving?

- auto-generated release notes are created without categories; a `release.yml` can be added to specify categorization based on labels (see [docs here](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) and usage in other repos).

## Short description of the changes

- add `release.yml` with categorization based on other repos like [honeycomb-opentelemetry-go](https://github.com/honeycombio/honeycomb-opentelemetry-go/blob/main/.github/release.yml)
- also add `type: dependencies` label for maintenance category to avoid it being always dumped in Other Changes

## How to verify that this has the expected result

next time we click auto-generate release notes we should see the changes in the appropriate categories based on label (or omitted entirely if set to `no-changelog`