### PR TITLE
Allow disabling the default span processor

### DIFF
--- a/otelconfig/pipelines/common.go
+++ b/otelconfig/pipelines/common.go
@@ -17,15 +17,16 @@ const (
 
 // PipelineConfig contains config info for a Pipeline.
 type PipelineConfig struct {
-	Protocol        Protocol
-	Endpoint        string
-	Insecure        bool
-	Headers         map[string]string
-	Resource        *resource.Resource
-	ReportingPeriod string
-	Propagators     []string
-	SpanProcessors  []trace.SpanProcessor
-	Sampler         trace.Sampler
+	Protocol                    Protocol
+	Endpoint                    string
+	Insecure                    bool
+	Headers                     map[string]string
+	Resource                    *resource.Resource
+	ReportingPeriod             string
+	Propagators                 []string
+	SpanProcessors              []trace.SpanProcessor
+	Sampler                     trace.Sampler
+	DisableDefaultSpanProcessor bool
 }
 
 // PipelineSetupFunc defines the interface for a Pipeline Setup function.


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #76

## Short description of the changes

Adds a new `Option`, `WithDisableDefaultSpanProcessor`, which will not create an internal `SpanProcessor`. In this case, the caller must provide at least one `SpanProcessor` via `WithSpanProcessor` or `ConfigureOpenTelemetry` will return an error.

## How to verify that this has the expected result

Basic unit tests provided.

Side note: I added a call to `require.NotPanics(...)` in one of the unit tests provided. This seems to add ~10 seconds of runtime to the tests for some reason on my machine. If that's a problem/annoying I can remove it.
