### PR TITLE
feat: Adds abilty to flush all configured exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Minimal setup - by default will send all telemetry via GRPC to `localhost:4317`
 import "github.com/honeycombio/otel-config-go/otelconfig"
 
 func main() {
-    otelShutdown, err := otelconfig.ConfigureOpenTelemetry()
+    otelShutdown, _, err := otelconfig.ConfigureOpenTelemetry()
     defer otelShutdown()
 }
 ```
@@ -34,7 +34,7 @@ You can set headers directly instead.
 import "github.com/honeycombio/otel-config-go/otelconfig"
 
 func main() {
-    otelShutdown, err := otelconfig.ConfigureOpenTelemetry(
+    otelShutdown, _, err := otelconfig.ConfigureOpenTelemetry(
         otelconfig.WithServiceName("service-name"),
         otelconfig.WithHeaders(map[string]string{
             "service-auth-key": "value",

--- a/examples/main.go
+++ b/examples/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	otelShutdown, err := otelconfig.ConfigureOpenTelemetry(
+	otelShutdown, otelFlush, err := otelconfig.ConfigureOpenTelemetry(
 		otelconfig.WithResourceOption(
 			resource.WithAttributes(
 				attribute.String("resource.example_set_in_code", "CODE"),
@@ -30,4 +30,7 @@ func main() {
 	ctx := context.Background()
 	ctx, span := tracer.Start(ctx, "doing-things")
 	defer span.End()
+
+	// optionally, flush any remaining spans
+	otelFlush(context.Background())
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	otelShutdown, otelFlush, err := otelconfig.ConfigureOpenTelemetry(
+	otelShutdown, _, err := otelconfig.ConfigureOpenTelemetry(
 		otelconfig.WithResourceOption(
 			resource.WithAttributes(
 				attribute.String("resource.example_set_in_code", "CODE"),
@@ -30,7 +30,4 @@ func main() {
 	ctx := context.Background()
 	ctx, span := tracer.Start(ctx, "doing-things")
 	defer span.End()
-
-	// optionally, flush any remaining spans
-	otelFlush(context.Background())
 }

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -153,7 +153,7 @@ func (t *testErrorHandler) Handle(err error) {
 
 func testEndpointDisabled(t *testing.T, expected string, opts ...Option) {
 	logger := &testLogger{}
-	shutdown, err := ConfigureOpenTelemetry(
+	shutdown, _, err := ConfigureOpenTelemetry(
 		append(opts,
 			WithLogger(logger),
 			WithServiceName("test-service"),
@@ -193,7 +193,7 @@ func TestValidConfig(t *testing.T) {
 	stopper := dummyGRPCListener()
 	defer stopper()
 
-	shutdown, err := ConfigureOpenTelemetry(
+	shutdown, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithServiceName("test-service"),
 		withTestExporters(),
@@ -211,7 +211,7 @@ func TestInvalidEnvironment(t *testing.T) {
 
 	logger := &testLogger{}
 
-	_, err := ConfigureOpenTelemetry(
+	_, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithServiceName("test-service"),
 	)
@@ -224,7 +224,7 @@ func TestInvalidMetricsPushIntervalEnv(t *testing.T) {
 	setenv("OTEL_EXPORTER_OTLP_METRICS_PERIOD", "300million")
 
 	logger := &testLogger{}
-	shutdown, err := ConfigureOpenTelemetry(
+	shutdown, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithServiceName("test-service"),
 		withTestExporters(),
@@ -236,7 +236,7 @@ func TestInvalidMetricsPushIntervalEnv(t *testing.T) {
 
 func TestInvalidMetricsPushIntervalConfig(t *testing.T) {
 	logger := &testLogger{}
-	shutdown, err := ConfigureOpenTelemetry(
+	shutdown, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithServiceName("test-service"),
 		WithMetricsReportingPeriod(-time.Second),
@@ -253,7 +253,7 @@ func TestDebugEnabled(t *testing.T) {
 	stopper := dummyGRPCListener()
 	defer stopper()
 
-	shutdown, _ := ConfigureOpenTelemetry(
+	shutdown, _, _ := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithServiceName("test-service"),
 		withTestExporters(),
@@ -511,7 +511,7 @@ func TestConfigurePropagators1(t *testing.T) {
 
 	unsetEnvironment()
 	logger := &testLogger{}
-	shutdown, err := ConfigureOpenTelemetry(
+	shutdown, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithServiceName("test-service"),
 		withTestExporters(),
@@ -543,7 +543,7 @@ func TestConfigurePropagators2(t *testing.T) {
 
 	unsetEnvironment()
 	logger := &testLogger{}
-	shutdown, err := ConfigureOpenTelemetry(
+	shutdown, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithServiceName("test-service"),
 		WithPropagators([]string{"b3", "baggage", "tracecontext"}),
@@ -571,7 +571,7 @@ func TestConfigurePropagators3(t *testing.T) {
 
 	unsetEnvironment()
 	logger := &testLogger{}
-	shutdown, err := ConfigureOpenTelemetry(
+	shutdown, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithServiceName("test-service"),
 		WithPropagators([]string{"invalid"}),
@@ -647,7 +647,7 @@ func TestServiceNameViaResourceAttributes(t *testing.T) {
 
 	setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=test-service-b")
 	logger := &testLogger{}
-	shutdown, _ := ConfigureOpenTelemetry(
+	shutdown, _, _ := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		withTestExporters(),
 	)
@@ -662,7 +662,7 @@ func TestEmptyHostnameDefaultsToOsHostname(t *testing.T) {
 	defer stopper()
 
 	setenv("OTEL_RESOURCE_ATTRIBUTES", "host.name=")
-	shutdown, _ := ConfigureOpenTelemetry(
+	shutdown, _, _ := ConfigureOpenTelemetry(
 		WithServiceName("test-service"),
 		WithTracesExporterEndpoint("localhost:443"),
 		WithResourceAttributes(map[string]string{
@@ -685,7 +685,7 @@ func TestConfigWithResourceAttributes(t *testing.T) {
 	stopper := dummyGRPCListener()
 	defer stopper()
 
-	shutdown, _ := ConfigureOpenTelemetry(
+	shutdown, _, _ := ConfigureOpenTelemetry(
 		WithServiceName("test-service"),
 		WithResourceAttributes(map[string]string{
 			"attr1": "val1",
@@ -716,7 +716,7 @@ func TestConfigWithResourceAttributesError(t *testing.T) {
 		return "", errors.New("faulty resource detector")
 	})
 
-	_, err := ConfigureOpenTelemetry(
+	_, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithResourceAttributes(map[string]string{
 			"attr1": "val1",
@@ -750,7 +750,7 @@ func TestConfigWithUnmergableResources(t *testing.T) {
 		return "attr.value", nil
 	})
 
-	_, err := ConfigureOpenTelemetry(
+	_, _, err := ConfigureOpenTelemetry(
 		WithServiceName("test-service"),
 		WithResourceOption(resource.WithDetectors(detect)),
 		withTestExporters(),
@@ -868,7 +868,7 @@ func TestHttpProtoDefaultsToCorrectHostAndPort(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	shutdown, err := ConfigureOpenTelemetry(
+	shutdown, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithExporterEndpoint(ts.URL),
 		WithExporterInsecure(true),
@@ -910,7 +910,7 @@ func TestCanUseCustomSampler(t *testing.T) {
 	stopper := dummyGRPCListenerWithTraceServer(traceServer)
 	defer stopper()
 
-	shutdown, err := ConfigureOpenTelemetry(
+	shutdown, _, err := ConfigureOpenTelemetry(
 		WithSampler(sampler),
 		withTestExporters(),
 	)
@@ -970,7 +970,7 @@ func TestResourceDetectorsDontError(t *testing.T) {
 	stopper := dummyGRPCListener()
 	defer stopper()
 
-	shutdown, err := ConfigureOpenTelemetry(
+	shutdown, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithResourceOption(resource.WithHost()),
 		withTestExporters(),
@@ -988,7 +988,7 @@ func TestContribResourceDetectorsDontError(t *testing.T) {
 	setenv("AWS_LAMBDA_FUNCTION_NAME", "lambdatest")
 	lambdaDetector := lambda.NewResourceDetector()
 
-	_, err := ConfigureOpenTelemetry(
+	_, _, err := ConfigureOpenTelemetry(
 		WithLogger(logger),
 		WithResourceOption(resource.WithDetectors(lambdaDetector)),
 		withTestExporters(),

--- a/otelconfig/pipelines/metrics.go
+++ b/otelconfig/pipelines/metrics.go
@@ -20,20 +20,20 @@ import (
 
 // NewMetricsPipeline takes a PipelineConfig and builds a metrics pipeline.
 // It returns a shutdown function that should be called when terminating the pipeline.
-func NewMetricsPipeline(c PipelineConfig) (func() error, error) {
+func NewMetricsPipeline(c PipelineConfig) (func() error, func(context.Context) error, error) {
 	metricExporter, err := newMetricsExporter(c.Protocol, c.Endpoint, c.Insecure, c.Headers)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create metric exporter: %v", err)
+		return nil, nil, fmt.Errorf("failed to create metric exporter: %v", err)
 	}
 
 	var readerOpts []metric.PeriodicReaderOption
 	if c.ReportingPeriod != "" {
 		period, err := time.ParseDuration(c.ReportingPeriod)
 		if err != nil {
-			return nil, fmt.Errorf("invalid metric reporting period: %v", err)
+			return nil, nil, fmt.Errorf("invalid metric reporting period: %v", err)
 		}
 		if period <= 0 {
-			return nil, fmt.Errorf("invalid metric reporting period: %v", c.ReportingPeriod)
+			return nil, nil, fmt.Errorf("invalid metric reporting period: %v", c.ReportingPeriod)
 		}
 		readerOpts = append(readerOpts, metric.WithInterval(period))
 	}
@@ -43,17 +43,17 @@ func NewMetricsPipeline(c PipelineConfig) (func() error, error) {
 		metric.WithReader(metric.NewPeriodicReader(metricExporter, readerOpts...)))
 
 	if err = runtimeMetrics.Start(runtimeMetrics.WithMeterProvider(meterProvider)); err != nil {
-		return nil, fmt.Errorf("failed to start runtime metrics: %v", err)
+		return nil, nil, fmt.Errorf("failed to start runtime metrics: %v", err)
 	}
 
 	if err = hostMetrics.Start(hostMetrics.WithMeterProvider(meterProvider)); err != nil {
-		return nil, fmt.Errorf("failed to start host metrics: %v", err)
+		return nil, nil, fmt.Errorf("failed to start host metrics: %v", err)
 	}
 
 	otel.SetMeterProvider(meterProvider)
 	return func() error {
 		return meterProvider.Shutdown(context.Background())
-	}, nil
+	}, meterProvider.ForceFlush, nil
 }
 
 //revive:disable:flag-parameter bools are fine for an internal function


### PR DESCRIPTION
## Which problem is this PR solving?
After configuring the OTel SDK, the configured trace and metric exporters are not exposed in any way to allow manual flushing. This is important in certain scenarios when the application life cycle does not want to wait or automatic flushing, eg in Lambda function.

This PR extends the config layer to allow manual flushing of the configured trace and metrics exporters.

- Closes #76

## Short description of the changes
- Extend config struct to hold `[]func(context) error` that matches the flush function signature
- Update both trace and metric pipeline builders to return their respective exporter flush functions as return parameters
- Add the returned flush funcs from pipelines to the config
- Return a new flush function from `ConfigureOpenTelemetry` that can be used to manually flush the configured exporters

## How to verify that this has the expected result
There's now a way to manually call flush on the configured exporters.