### PR TITLE
maint: Add dependency groups for otel and otel contrib packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,10 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
-      
+    groups:
+      otel-dependencies:
+        patterns:
+          - "go.opentelemetry.io/otel/*"
+      otel-contrib-dependencies:
+        patterns:
+          - "go.opentelemetry.io/contrib/*"


### PR DESCRIPTION
## Which problem is this PR solving?
Adds dependency groups to dependabot config so related packages are updated together. 

## Short description of the changes
- Add groups for otel and otel-contrib to dependabot config

## How to verify that this has the expected result
Dependabot will group otel and otel contrib packages into PRs. 