### PR TITLE
maint: combine otel core and contrib in dependabot groups 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,4 @@ updates:
       otel-dependencies:
         patterns:
           - "go.opentelemetry.io/otel/*"
-      otel-contrib-dependencies:
-        patterns:
           - "go.opentelemetry.io/contrib/*"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Latest release built with:
 - OpenTelemetry Go Contrib [v1.21.1/v0.46.1](https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.21.1)
 - OpenTelemetry Semantic Conventions [v1.21.0](https://github.com/open-telemetry/opentelemetry-go/tree/main/semconv/v1.21.0)
 
-(Note: semantic conventions to be updated to match upstream in next release)
-
 Minimum Go Version: `1.20`
 
 See the OpenTelemetry SDK's [compatability matrix](https://github.com/open-telemetry/opentelemetry-go#compatibility) for more information.


### PR DESCRIPTION
## Which problem is this PR solving?

- all otel dependencies should be updated together

## Short description of the changes

- include both core and contrib otel deps in one dependabot group
- remove old line from readme that should've been deleted a while back

## How to verify that this has the expected result

all core and contrib packages should be included in a single dependabot group PR