### PR TITLE
fix(pipelines): use protocol constants

### DIFF
--- a/otelconfig/pipelines/metrics.go
+++ b/otelconfig/pipelines/metrics.go
@@ -59,11 +59,11 @@ func NewMetricsPipeline(c PipelineConfig) (func() error, error) {
 //revive:disable:flag-parameter bools are fine for an internal function
 func newMetricsExporter(protocol Protocol, endpoint string, insecure bool, headers map[string]string) (metric.Exporter, error) {
 	switch protocol {
-	case "grpc":
+	case ProtocolGRPC:
 		return newGRPCMetricsExporter(endpoint, insecure, headers)
-	case "http/protobuf":
+	case ProtocolHTTPProtobuf:
 		return newHTTPMetricsExporter(endpoint, insecure, headers)
-	case "http/json":
+	case ProtocolHTTPJSON:
 		return nil, errors.New("http/json is currently unsupported")
 	default:
 		return nil, errors.New("'" + string(protocol) + "' is not a supported protocol")

--- a/otelconfig/pipelines/trace.go
+++ b/otelconfig/pipelines/trace.go
@@ -55,11 +55,11 @@ func NewTracePipeline(c PipelineConfig) (func() error, error) {
 //revive:disable:flag-parameter bools are fine for an internal function
 func newTraceExporter(protocol Protocol, endpoint string, insecure bool, headers map[string]string) (*otlptrace.Exporter, error) {
 	switch protocol {
-	case "grpc":
+	case ProtocolGRPC:
 		return newGRPCTraceExporter(endpoint, insecure, headers)
-	case "http/protobuf":
+	case ProtocolHTTPProtobuf:
 		return newHTTPTraceExporter(endpoint, insecure, headers)
-	case "http/json":
+	case ProtocolHTTPJSON:
 		return nil, errors.New("http/json is currently unsupported")
 	default:
 		return nil, errors.New("'" + string(protocol) + "' is not a supported protocol")


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Use predefined protocol constants instead of hard-coding the strings.

## Short description of the changes

## How to verify that this has the expected result
