### PR TITLE
fix: remove duplicate secureOption assignment

### DIFF
--- a/otelconfig/pipelines/metrics.go
+++ b/otelconfig/pipelines/metrics.go
@@ -90,9 +90,6 @@ func newHTTPMetricsExporter(endpoint string, insecure bool, headers map[string]s
 	if insecure {
 		secureOption = otlpmetrichttp.WithInsecure()
 	}
-	if insecure {
-		secureOption = otlpmetrichttp.WithInsecure()
-	}
 	return otlpmetrichttp.New(
 		context.Background(),
 		secureOption,


### PR DESCRIPTION
## Which problem is this PR solving?

- Simple maintenance

## Short description of the changes that set the metric exporter's `WithSecure` option.

Removes a duplicated block of code that set the metric exporter's `WithSecure` option.

## How to verify that this has the expected result

As expected, this removed code doesn't change the current behavior of the library.