### PR TITLE
Fix/empty headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ As of v1.8.0, this package has been renamed from `otel-launcher-go` to `otel-con
 | WithServiceName             | OTEL_SERVICE_NAME                   | y        | -                    |
 | WithServiceVersion          | OTEL_SERVICE_VERSION                | n        | -                    |
 | WithHeaders                 | OTEL_EXPORTER_OTLP_HEADERS          | n        | {}                   |
+| WithTracesHeaders           | OTEL_EXPORTER_OTLP_TRACES_HEADERS   | n        | {}                   |
+| WithMetricsHeaders          | OTEL_EXPORTER_OTLP_METRICS_HEADERS  | n        | {}                   |
 | WithExporterProtocol        | OTEL_EXPORTER_OTLP_PROTOCOL         | n        | grpc                 |
 | WithTracesExporterEndpoint  | OTEL_EXPORTER_OTLP_TRACES_ENDPOINT  | n        | localhost:4317       |
 | WithTracesExporterInsecure  | OTEL_EXPORTER_OTLP_TRACES_INSECURE  | n        | false                |

--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -318,9 +318,9 @@ type Config struct {
 	ExporterProtocol                Protocol          `env:"OTEL_EXPORTER_OTLP_PROTOCOL,default=grpc"`
 	TracesExporterProtocol          Protocol          `env:"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"`
 	MetricsExporterProtocol         Protocol          `env:"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"`
-	Headers                         map[string]string `env:"OTEL_EXPORTER_OTLP_HEADERS,separator=="`
-	TracesHeaders                   map[string]string `env:"OTEL_EXPORTER_OTLP_TRACES_HEADERS,separator=="`
-	MetricsHeaders                  map[string]string `env:"OTEL_EXPORTER_OTLP_METRICS_HEADERS,separator=="`
+	Headers                         map[string]string `env:"OTEL_EXPORTER_OTLP_HEADERS,overwrite,separator=="`
+	TracesHeaders                   map[string]string `env:"OTEL_EXPORTER_OTLP_TRACES_HEADERS,overwrite,separator=="`
+	MetricsHeaders                  map[string]string `env:"OTEL_EXPORTER_OTLP_METRICS_HEADERS,overwrite,separator=="`
 	ResourceAttributes              map[string]string
 	SpanProcessors                  []trace.SpanProcessor
 	Sampler                         trace.Sampler
@@ -334,6 +334,9 @@ type Config struct {
 func newConfig(opts ...Option) (*Config, error) {
 	c := &Config{
 		ResourceAttributes: map[string]string{},
+		Headers:            map[string]string{},
+		TracesHeaders:      map[string]string{},
+		MetricsHeaders:     map[string]string{},
 		Logger:             defLogger,
 		errorHandler:       &defaultHandler{logger: defLogger},
 		Sampler:            trace.AlwaysSample(),
@@ -347,18 +350,6 @@ func newConfig(opts ...Option) (*Config, error) {
 	// if exporter endpoint is not set using an env var, use the configured default
 	if c.ExporterEndpoint == "" {
 		c.ExporterEndpoint = DefaultExporterEndpoint
-	}
-
-	if c.Headers == nil {
-		c.Headers = map[string]string{}
-	}
-
-	if c.TracesHeaders == nil {
-		c.TracesHeaders = map[string]string{}
-	}
-
-	if c.MetricsHeaders == nil {
-		c.MetricsHeaders = map[string]string{}
 	}
 
 	// If a vendor has specific options to add, add them to opts

--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -333,10 +333,10 @@ type Config struct {
 
 func newConfig(opts ...Option) (*Config, error) {
 	c := &Config{
-		ResourceAttributes: map[string]string{},
 		Headers:            map[string]string{},
 		TracesHeaders:      map[string]string{},
 		MetricsHeaders:     map[string]string{},
+		ResourceAttributes: map[string]string{},
 		Logger:             defLogger,
 		errorHandler:       &defaultHandler{logger: defLogger},
 		Sampler:            trace.AlwaysSample(),

--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -301,26 +301,26 @@ func (l *defaultHandler) Handle(err error) {
 // vary depending on the protocol chosen. If not overridden by explicit configuration, it will
 // be overridden with an appropriate default upon initialization.
 type Config struct {
-	ExporterEndpoint                string   `env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-	ExporterEndpointInsecure        bool     `env:"OTEL_EXPORTER_OTLP_INSECURE,default=false"`
-	TracesExporterEndpoint          string   `env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"`
-	TracesExporterEndpointInsecure  bool     `env:"OTEL_EXPORTER_OTLP_TRACES_INSECURE"`
-	TracesEnabled                   bool     `env:"OTEL_TRACES_ENABLED,default=true"`
-	ServiceName                     string   `env:"OTEL_SERVICE_NAME"`
-	ServiceVersion                  string   `env:"OTEL_SERVICE_VERSION,default=unknown"`
-	MetricsExporterEndpoint         string   `env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
-	MetricsExporterEndpointInsecure bool     `env:"OTEL_EXPORTER_OTLP_METRICS_INSECURE"`
-	MetricsEnabled                  bool     `env:"OTEL_METRICS_ENABLED,default=true"`
-	MetricsReportingPeriod          string   `env:"OTEL_EXPORTER_OTLP_METRICS_PERIOD,default=30s"`
-	LogLevel                        string   `env:"OTEL_LOG_LEVEL,default=info"`
-	Propagators                     []string `env:"OTEL_PROPAGATORS,default=tracecontext,baggage"`
-	ResourceAttributesFromEnv       string   `env:"OTEL_RESOURCE_ATTRIBUTES"`
-	ExporterProtocol                Protocol `env:"OTEL_EXPORTER_OTLP_PROTOCOL,default=grpc"`
-	TracesExporterProtocol          Protocol `env:"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"`
-	MetricsExporterProtocol         Protocol `env:"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"`
-	Headers                         map[string]string
-	TracesHeaders                   map[string]string
-	MetricsHeaders                  map[string]string
+	ExporterEndpoint                string            `env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	ExporterEndpointInsecure        bool              `env:"OTEL_EXPORTER_OTLP_INSECURE,default=false"`
+	TracesExporterEndpoint          string            `env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"`
+	TracesExporterEndpointInsecure  bool              `env:"OTEL_EXPORTER_OTLP_TRACES_INSECURE"`
+	TracesEnabled                   bool              `env:"OTEL_TRACES_ENABLED,default=true"`
+	ServiceName                     string            `env:"OTEL_SERVICE_NAME"`
+	ServiceVersion                  string            `env:"OTEL_SERVICE_VERSION,default=unknown"`
+	MetricsExporterEndpoint         string            `env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
+	MetricsExporterEndpointInsecure bool              `env:"OTEL_EXPORTER_OTLP_METRICS_INSECURE"`
+	MetricsEnabled                  bool              `env:"OTEL_METRICS_ENABLED,default=true"`
+	MetricsReportingPeriod          string            `env:"OTEL_EXPORTER_OTLP_METRICS_PERIOD,default=30s"`
+	LogLevel                        string            `env:"OTEL_LOG_LEVEL,default=info"`
+	Propagators                     []string          `env:"OTEL_PROPAGATORS,default=tracecontext,baggage"`
+	ResourceAttributesFromEnv       string            `env:"OTEL_RESOURCE_ATTRIBUTES"`
+	ExporterProtocol                Protocol          `env:"OTEL_EXPORTER_OTLP_PROTOCOL,default=grpc"`
+	TracesExporterProtocol          Protocol          `env:"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"`
+	MetricsExporterProtocol         Protocol          `env:"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"`
+	Headers                         map[string]string `env:"OTEL_EXPORTER_OTLP_HEADERS,separator=="`
+	TracesHeaders                   map[string]string `env:"OTEL_EXPORTER_OTLP_TRACES_HEADERS,separator=="`
+	MetricsHeaders                  map[string]string `env:"OTEL_EXPORTER_OTLP_METRICS_HEADERS,separator=="`
 	ResourceAttributes              map[string]string
 	SpanProcessors                  []trace.SpanProcessor
 	Sampler                         trace.Sampler
@@ -333,9 +333,6 @@ type Config struct {
 
 func newConfig(opts ...Option) (*Config, error) {
 	c := &Config{
-		Headers:            map[string]string{},
-		TracesHeaders:      map[string]string{},
-		MetricsHeaders:     map[string]string{},
 		ResourceAttributes: map[string]string{},
 		Logger:             defLogger,
 		errorHandler:       &defaultHandler{logger: defLogger},

--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -349,6 +349,18 @@ func newConfig(opts ...Option) (*Config, error) {
 		c.ExporterEndpoint = DefaultExporterEndpoint
 	}
 
+	if c.Headers == nil {
+		c.Headers = map[string]string{}
+	}
+
+	if c.TracesHeaders == nil {
+		c.TracesHeaders = map[string]string{}
+	}
+
+	if c.MetricsHeaders == nil {
+		c.MetricsHeaders = map[string]string{}
+	}
+
 	// If a vendor has specific options to add, add them to opts
 	vendorOpts := []Option{}
 	if SetVendorOptions != nil {


### PR DESCRIPTION
Headers can't be set via the environment variables specified in the [OTEL SDK configuration documentation](https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#header-configuration). Since headers are often used to affect authentication, using the provided options isn't always desirable or safe.

## Which problem is this PR solving?

- Closes #98

## Short description of the changes

This PR adds the required field tags to the `Config` struct and documents the existing options as well as the affected environment variables.

## How to verify that this has the expected result

Set headers via environment variables and verify that the headers are received by an OTEL collector.