### PR TITLE
rel: Prepare v1.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 - feat: Populate headers from specified environment variables (#99) | @smoyer64
-- feat: Add additional tests for handling OTel env vars for signal generic and specific exporter headers | @MikeGoldsmith
+- feat: Add additional tests for handling OTel env vars for signal generic and specific exporter headers (#106) | @MikeGoldsmith
 
 ### Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- fix(headers): Populate headers from specified environment variables (#99) | @smoyer64
+- feat: Populate headers from specified environment variables (#99) | @smoyer64
 - feat: Add additional tests for handling OTel env vars for signal generic and specific exporter headers | @MikeGoldsmith
 
 ### Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # otel-config-go changelog
 
+## v1.14.0 (2024-02-06)
+
+### Enhancements
+
+- fix(headers): Populate headers from specified environment variables (#99) | @smoyer64
+- feat: Add additional tests for handling OTel env vars for signal generic and specific exporter headers | @MikeGoldsmith
+
+### Maintenance
+
+- maint: update codeowners to pipeline-team (#97) | @JamieDanielson
+- maint: update codeowners to pipeline (#96) | @JamieDanielson
+- maint(deps): bump go.opentelemetry.io/proto/otlp from 1.0.0 to 1.1.0 (#105) | @Dependabot
+- maint(deps): bump go.opentelemetry.io/otel from 1.21.0 to 1.22.0 (#102) | @Dependabot
+- maint(deps): bump google.golang.org/grpc from 1.60.1 to 1.61.0 (#103) | @Dependabot
+- maint(deps): bump google.golang.org/grpc from 1.59.0 to 1.60.1 (#100) | @Dependabot
+
 ## v1.13.1 (2023-12-04)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@
 - feat: Populate headers from specified environment variables (#99) | @smoyer64
 - feat: Add additional tests for handling OTel env vars for signal generic and specific exporter headers (#106) | @MikeGoldsmith
 
+### Fixes
+
+- fix: Prefer environment variables over code configuration (#106) | @MikeGoldsmith
+
 ### Maintenance
 
+- maint: upload test results to CircleCI & add Go 1.22 to test matrix (#108) | @robbkidd
 - maint: update codeowners to pipeline-team (#97) | @JamieDanielson
 - maint: update codeowners to pipeline (#96) | @JamieDanielson
 - maint(deps): bump go.opentelemetry.io/proto/otlp from 1.0.0 to 1.1.0 (#105) | @Dependabot

--- a/otelconfig/version.go
+++ b/otelconfig/version.go
@@ -1,3 +1,3 @@
 package otelconfig
 
-const version = "1.13.1"
+const version = "1.14.0"


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares next release of otel-config-go.

## Short description of the changes
- Updates version to 1.14.0
- Adds changelog entry

## How to verify that this has the expected result
Next release of otel-config-go can be tagged and published.