### PR TITLE
maint: upload test results to CircleCI & add Go 1.22 to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,8 @@ jobs:
           keys:
             - v1-go-mod-{{ checksum "go.sum" }}
       - run: make test
+      - store_test_results:
+          path: test_results
       - save_cache:
           key: v1-go-mod-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["20", "21"]
+      goversion: ["20", "21", "22"]
 
-default_goversion: &default_goversion "21"
+default_goversion: &default_goversion "22"
 
 orbs:
   bats: circleci/bats@1.0.0

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@ clean:
 	rm -rf ./smoke-tests/collector/data-results/*.json
 	rm -rf ./smoke-tests/report.*
 
+GOTESTCMD = $(if $(shell command -v gotestsum),gotestsum --junitfile ./test_results/$(1).xml --format testname --,go test)
+
 test:
-	go test -v ./...
+	$(call GOTESTCMD,$@) -v ./...
 
 smoke-tests/collector/data.json:
 	@echo ""


### PR DESCRIPTION
We upload test reports for smoke tests for friendlier error reporting and tracking flaky tests. This lets us do that for unit tests, too.

## Which problem is this PR solving?

- Friendlier error reporting in CI.
- Test coverage for recently release Go 1.22.

## Short description of the changes

- gotestsum is on Circle's current Go runners, so we can use it to produce xUnit XML test run reports to upload to Circle.
- New Go is out. Let's test against it.

## How to verify that this has the expected result

A unit test build's "TESTS" tab at Circle will have data instead of reporting "0 test results uploaded".
