### PR TITLE
maint: Update ubuntu image in workflows to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
 
   smoke_test:
     machine:
-      image: ubuntu-2004:2023.04.2
+      image: ubuntu-2204:2024.01.1
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
## Which problem is this PR solving?
Older ubuntu images used in our workflows are being marked as deprecated. We need to update to newer ones.

## Short description of the changes
- Update workflows images to use `ubuntu-2204:2024.01.1` image

