### PR TITLE
rel: Prepare v1.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # otel-config-go changelog
 
+## v1.15.0 (2024-04-10)
+
+### Maintenance
+
+- maint: update dependencies to 1.25.0 (#117) | @codeboten
+- maint: Update ubuntu image in workflows to latest (#113) | @MikeGoldsmith
+- maint: add labels to release.yml for auto-generated grouping (#112) | @JamieDanielson
+
 ## v1.14.0 (2024-02-06)
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This project is a configuration layer that chooses default values for configurat
 
 Latest release built with:
 
-- OpenTelemetry Go [v1.21.0/v0.44.0](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.21.0)
-- OpenTelemetry Go Contrib [v1.21.1/v0.46.1](https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.21.1)
-- OpenTelemetry Semantic Conventions [v1.21.0](https://github.com/open-telemetry/opentelemetry-go/tree/main/semconv/v1.21.0)
+- OpenTelemetry Go [v1.25.0/v0.47.0](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.25.0)
+- OpenTelemetry Go Contrib [v1.25.0/v0.50.0](https://github.com/open-telemetry/opentelemetry-go-contrib/releases/tag/v1.25.0)
+- OpenTelemetry Semantic Conventions [v1.24.0](https://github.com/open-telemetry/opentelemetry-go/tree/main/semconv/v1.24.0)
 
-Minimum Go Version: `1.20`
+Minimum Go Version: `1.21`
 
 See the OpenTelemetry SDK's [compatability matrix](https://github.com/open-telemetry/opentelemetry-go#compatibility) for more information.
 

--- a/otelconfig/version.go
+++ b/otelconfig/version.go
@@ -1,3 +1,3 @@
 package otelconfig
 
-const version = "1.14.0"
+const version = "1.15.0"


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares next release of otel-config-go.

## Short description of the changes
- Updates version to 1.15.0
- Adds changelog entry

## How to verify that this has the expected result
Next release of otel-config-go can be tagged and published.