### PR TITLE
fix: allow disabling of config options that default to true

### DIFF
--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -575,7 +575,11 @@ func setupTracing(c *Config) (func() error, error) {
 	} else {
 		enabled = *c.TracesEnabled
 	}
-	if !enabled || endpoint == "" {
+	if !enabled {
+		c.Logger.Debugf("tracing is disabled by configuration: enabled set to false")
+		return nil, nil
+	}
+	if endpoint == "" {
 		c.Logger.Debugf("tracing is disabled by configuration: no endpoint set")
 		return nil, nil
 	}
@@ -600,7 +604,11 @@ func setupMetrics(c *Config) (func() error, error) {
 	} else {
 		enabled = *c.MetricsEnabled
 	}
-	if !enabled || endpoint == "" {
+	if !enabled {
+		c.Logger.Debugf("metrics are disabled by configuration: enabled set to false")
+		return nil, nil
+	}
+	if endpoint == "" {
 		c.Logger.Debugf("metrics are disabled by configuration: no endpoint set")
 		return nil, nil
 	}

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -183,6 +183,36 @@ func TestMetricEndpointDisabled(t *testing.T) {
 	)
 }
 
+func testSignalDisabled(t *testing.T, expected string, opts ...Option) {
+	logger := &testLogger{}
+	shutdown, err := ConfigureOpenTelemetry(
+		append(opts,
+			WithLogger(logger),
+			WithServiceName("test-service"),
+		)...,
+	)
+	require.NoError(t, err)
+	defer shutdown()
+
+	logger.requireContains(t, expected)
+}
+
+func TestMetricsDisabled(t *testing.T) {
+	testSignalDisabled(
+		t,
+		expectedMetricsDisabledMessage,
+		WithMetricsEnabled(false),
+	)
+}
+
+func TestTracesDisabled(t *testing.T) {
+	testSignalDisabled(
+		t,
+		expectedTracingDisabledMessage,
+		WithTracesEnabled(false),
+	)
+}
+
 func TestValidConfig(t *testing.T) {
 	logger := &testLogger{}
 

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -31,8 +31,10 @@ import (
 //revive:disable:import-shadowing this is a test file
 
 const (
-	expectedTracingDisabledMessage = "tracing is disabled by configuration: no endpoint set"
-	expectedMetricsDisabledMessage = "metrics are disabled by configuration: no endpoint set"
+	expectedTracingDisabledMessage       = "tracing is disabled by configuration: no endpoint set"
+	expectedMetricsDisabledMessage       = "metrics are disabled by configuration: no endpoint set"
+	expectedTracingDisabledConfigMessage = "tracing is disabled by configuration: enabled set to false"
+	expectedMetricsDisabledConfigMessage = "metrics are disabled by configuration: enabled set to false"
 )
 
 type testLogger struct {
@@ -203,7 +205,7 @@ func testSignalDisabled(t *testing.T, expected string, opts ...Option) {
 func TestMetricsDisabled(t *testing.T) {
 	testSignalDisabled(
 		t,
-		expectedMetricsDisabledMessage,
+		expectedMetricsDisabledConfigMessage,
 		WithMetricsEnabled(false),
 	)
 }
@@ -211,7 +213,7 @@ func TestMetricsDisabled(t *testing.T) {
 func TestTracesDisabled(t *testing.T) {
 	testSignalDisabled(
 		t,
-		expectedTracingDisabledMessage,
+		expectedTracingDisabledConfigMessage,
 		WithTracesEnabled(false),
 	)
 }

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -72,6 +72,9 @@ func (logger *testLogger) requireNotContains(t *testing.T, expected string) {
 	}
 }
 
+var trueVal = true
+var falseVal = false
+
 // Create some dummy server implementations so that we can
 // spin up tests that don't need to wait for a timeout trying to send data.
 type dummyTraceServer struct {
@@ -324,12 +327,12 @@ func TestDefaultConfig(t *testing.T) {
 		ExporterEndpointInsecure:        false,
 		TracesExporterEndpoint:          "",
 		TracesExporterEndpointInsecure:  false,
-		TracesEnabled:                   true,
+		TracesEnabled:                   &trueVal,
 		ServiceName:                     "",
 		ServiceVersion:                  "unknown",
 		MetricsExporterEndpoint:         "",
 		MetricsExporterEndpointInsecure: false,
-		MetricsEnabled:                  true,
+		MetricsEnabled:                  &trueVal,
 		MetricsReportingPeriod:          "30s",
 		LogLevel:                        "info",
 		Headers:                         map[string]string{},
@@ -405,11 +408,12 @@ func TestEnvironmentVariables(t *testing.T) {
 		ExporterEndpointInsecure:        true,
 		ExporterProtocol:                Protocol(environmentOtelSettings["OTEL_EXPORTER_OTLP_PROTOCOL"]),
 		Headers:                         map[string]string{"env-headers": "present", "header-clobber": "ENV_WON"},
-		TracesEnabled:                   true,
+		TracesEnabled:                   &trueVal,
 		TracesExporterEndpoint:          environmentOtelSettings["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"],
 		TracesExporterEndpointInsecure:  true,
 		TracesExporterProtocol:          Protocol(environmentOtelSettings["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"]),
 		TracesHeaders:                   map[string]string{"env-traces-headers": "present", "header-clobber": "ENV_WON"},
+		MetricsEnabled:                  &falseVal,
 		MetricsExporterEndpoint:         environmentOtelSettings["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"],
 		MetricsExporterEndpointInsecure: true,
 		MetricsExporterProtocol:         Protocol(environmentOtelSettings["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"]),
@@ -508,7 +512,8 @@ func TestConfigurationOverrides(t *testing.T) {
 		ExporterEndpointInsecure:        true,
 		ExporterProtocol:                Protocol(environmentOtelSettings["OTEL_EXPORTER_OTLP_PROTOCOL"]),
 		Headers:                         map[string]string{"env-headers": "present", "header-clobber": "ENV_WON"},
-		TracesEnabled:                   true,
+		TracesEnabled:                   &trueVal,
+		MetricsEnabled:                  &falseVal,
 		TracesExporterEndpoint:          environmentOtelSettings["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"],
 		TracesExporterEndpointInsecure:  true,
 		TracesExporterProtocol:          Protocol(environmentOtelSettings["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"]),


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #120 

## Short description of the changes

- Set default true options to use a pointer to a bool to allow overriding in code
- Add unit tests to check for in-code setting of Metrics or Traces Disabled
- Use separate message to clarify if signal is disabled due to missing endpoint or enabled set to false

## How to verify that this has the expected result

Set `WithMetricsEnabled(false)` and `WithLogLevel("debug")` and see `MetricsEnabled` set to false. Same should hold for Traces now as well.