### PR TITLE
fix: ignore schema URL conflicts

### DIFF
--- a/otelconfig/otelconfig.go
+++ b/otelconfig/otelconfig.go
@@ -3,6 +3,7 @@ package otelconfig
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -371,6 +372,15 @@ func newConfig(opts ...Option) (*Config, error) {
 
 	var err error
 	c.Resource, err = newResource(c)
+
+	if err != nil {
+		if errors.Is(err, resource.ErrSchemaURLConflict) {
+			c.Logger.Debugf("schema conflict %v", err)
+			// ignore schema conflicts
+			err = nil
+		}
+	}
+
 	return c, err
 }
 

--- a/otelconfig/otelconfig_test.go
+++ b/otelconfig/otelconfig_test.go
@@ -884,7 +884,18 @@ func TestConfigWithUnmergableResources(t *testing.T) {
 		WithResourceOption(resource.WithDetectors(detect)),
 		withTestExporters(),
 	)
-	assert.ErrorContains(t, err, "conflicting Schema URL")
+	assert.NoError(t, err, "no conflicting Schema URL should be returned")
+
+	r, err := newResource(&Config{
+		ResourceOptions: []resource.Option{
+			resource.WithSchemaURL("1234"),
+		},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, "", r.SchemaURL())
+	cfg, err := newConfig(WithResourceOption(resource.WithSchemaURL("1234")))
+	assert.NoError(t, err)
+	assert.Equal(t, "", cfg.Resource.SchemaURL())
 }
 
 func TestThatEndpointsFallBackCorrectly(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

The current behaviour of returning an error is causing more problems than addressing problems

## Short description of the changes

With this change, the error will be logged and ignored if it's a schema URL error.

## How to verify that this has the expected result

1. Manually tested by running the example code w/ an import of a newer SDK than what is used in the current otel-config-go package
2. Updated unit test to include additional case