### PR TITLE
ci(OTEL-125): remove pipeline-team dependabot reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       interval: "monthly"
     labels:
       - "type: dependencies"
-    reviewers:
-      - "honeycombio/pipeline-team"
     commit-message:
       prefix: "maint"
       include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

Removes the hardcoded `honeycombio/pipeline-team` reviewer from the dependabot config as part of renaming the GitHub team.

## Short description of the changes

- Removes the `reviewers` entry from `.github/dependabot.yml`

Dependabot PRs will still require a review via the CODEOWNERS branch protection rule.

Part of OTEL-125